### PR TITLE
Support OpenID logins

### DIFF
--- a/app/gonuts/controllers/base.go
+++ b/app/gonuts/controllers/base.go
@@ -60,6 +60,7 @@ func init() {
 	Router.Get("/-/me", appstats.NewHandler(myHandler))
 	Router.Post("/-/me/register", appstats.NewHandler(registerHandler))
 	Router.Get("/-/me/generate", appstats.NewHandler(generateHandler))
+	Router.Post("/-/me/openid", appstats.NewHandler(openIdHandler))
 	Router.Get("/-/nuts", appstats.NewHandler(nutsHandler))
 
 	Router.Put("/:vendor/:name/:version", appstats.NewHandler(nutCreateHandler))

--- a/app/gonuts/models.go
+++ b/app/gonuts/models.go
@@ -15,11 +15,12 @@ import (
 
 type User struct {
 	// StringID (entity name, key name) is appengine/user.User.ID
-	Id      string // same as StringID
-	Email   string
-	Token   string
-	Debug   bool
-	Vendors []string
+	Id                string // same as StringID
+	Email             string
+	Token             string
+	Debug             bool
+	Vendors           []string
+	FederatedIdentity string
 }
 
 func UserKey(c appengine.Context, u *user.User) *datastore.Key {
@@ -52,6 +53,15 @@ func (user *User) AddVendor(vendor *Vendor) {
 	}
 	sort.Strings(users)
 	vendor.UserStringID = users
+}
+
+func (user *User) Identifier() (string, error) {
+	if user.Email != "" {
+		return user.Email, nil
+	} else if user.FederatedIdentity != "" {
+		return user.FederatedIdentity, nil
+	}
+	return "", fmt.Errorf("User %s has neither email nor federated identity", user.Id)
 }
 
 type Vendor struct {

--- a/app/gonuts/templates/base/me.html
+++ b/app/gonuts/templates/base/me.html
@@ -1,9 +1,16 @@
 {{if .LoginURL}}
 	<p><a href="{{.LoginURL}}">Login with Google account.</a><p>
+	<p>
+	  Or login with an OpenID provider:
+	  <form method="POST" action="{{.OpenIDURL}}">
+	    <input type="text" name="provider" value="" />
+	    <input type="submit"  value="Login" />
+	  </form>
+	</p>
 {{else}}
 	{{if .Token}}
 		<p>
-			You are logged in and registered with Google account <code>{{.Email}}</code>. <a href="{{.LogoutURL}}">Logout</a>.
+			You are logged in and registered with user account <code>{{.Identifier}}</code>. <a href="{{.LogoutURL}}">Logout</a>.
 		</p>
 		<p>
 			Your access token is <code>{{.Token}}</code>. <a href="{{.GenerateURL}}">Regenerate</a>.
@@ -18,7 +25,7 @@
 		</p>
 	{{else}}
 		<p>
-			You are logged in with Google account <code>{{.Email}}</code> but not registered yet.
+			You are logged in with user account <code>{{.Identifier}}</code> but not registered yet.
 		</p>
 		<p>
 			Choose vendor (user) name.
@@ -28,7 +35,7 @@
 			</form>
 		</p>
 		<p>
-			Or <a href="{{.LogoutURL}}">logout</a> and use different Google account.
+			Or <a href="{{.LogoutURL}}">logout</a> and use different Google or OpenID account.
 		</p>
 	{{end}}
 {{end}}


### PR DESCRIPTION
A patch to enable OpenID login, as described in AlekSi/gonuts.io#23 .  It's not possible to test this patch in the AppEngine SDK, as it substitutes its own login screen regardless of what login method you choose, but it does work in regular AppEngine, provided you enable Federated logins in the app settings screen.

Also, this login method does not return an email address, only a FederatedIdentity field to identify the user.  Not sure if this will be human-readable for all OpenID providers.
